### PR TITLE
Fixing the bug where upon the first download, callback wont be triggered.

### DIFF
--- a/android/src/main/java/com/masteratul/downloadmanager/ReactNativeDownloadManagerModule.java
+++ b/android/src/main/java/com/masteratul/downloadmanager/ReactNativeDownloadManagerModule.java
@@ -26,7 +26,7 @@ public class ReactNativeDownloadManagerModule extends ReactContextBaseJavaModule
         public void onReceive(Context context, Intent intent) {
             try {
                 long downloadId = intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1);
-                if (appDownloads.indexOfKey(downloadId) > 0) {
+                if (appDownloads.indexOfKey(downloadId) >= 0) {
                     WritableMap downloadStatus = downloader.checkDownloadStatus(downloadId);
                     Callback downloadOnDoneCb = appDownloads.get(downloadId);
 


### PR DESCRIPTION
Since indexOfKey returns the index at which the key was found and if the key is at the first index (ie 0), the if case would fail. Causing the callback not being called.